### PR TITLE
README - default values for useForm example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ function App() {
 #### After
 ```jsx
 function App() {
-  const [{firstName, lastName}, setValue] = useForm({first, last});
+  const [{firstName, lastName}, setValue] = useForm({first: "", last: ""});
   return (
     <div className="App">
       <input name="first" onChange={setValue} />


### PR DESCRIPTION
thanks for the repo! you write great READMEs imo. this pr is a fix for what I assume was a typo.

explanation - `{first, last}` desugars to `{first: first, last: last}`, but first and last aren't defined anywhere (and because of js quirks, will think it means `window.first` and `window.last` as the values). this fix removes the shorthand to be more explicit and avoids the bug.

(I don't know why the last [ MIT ] line is showing in the diff, I edited this in the github editor directly)